### PR TITLE
Add experimental warp support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,11 @@ hyper = { version = "0.13", optional = true }
 actix-web = { version = "2.0", optional = true }
 actix = { version = "0.9", optional = true }
 failure = { version = "0.1", optional = true }
+warp = { version = "0.2", optional = true }
 
 [features]
 with_actix_web = ["actix-web", "actix"]
 with_hyper = ["hyper"]
 #with_rocket = ["rocket"]
 with_api_error = ["failure"]
+with_warp = ["warp"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,6 +621,9 @@ impl<'r> ::rocket::response::Responder<'r> for HttpApiProblem {
     }
 }
 
+#[cfg(feature = "with_warp")]
+impl warp::reject::Reject for HttpApiProblem {}
+
 mod custom_http_status_serialization {
     use std::convert::TryFrom;
     use http::StatusCode;


### PR DESCRIPTION
`warp 0.2` makes some changes in how it handles custom rejections. To allow an error to be used as a custom rejection, it needs to implement `warp::reject::Reject`.

This patch implements this trait on that type.