### PR TITLE
Replace CI with GitHub actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        features: ["--no-default-features", "--all-features", ""]
+        rust: [
+          1.39.0, # MSRV
+          nightly # it is good practise to test libraries against nightly to catch regressions in the compiler early
+        ]
+      fail-fast: false # don't want to kill the whole CI if nightly fails
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Cache target directory
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: target-directory-${{ matrix.rust }}-${{ matrix.features }}-${{ hashFiles('Cargo.toml') }}
+
+      - run: cargo build ${{ matrix.features }}
+      - run: cargo test ${{ matrix.features }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: rust
-rust: stable


### PR DESCRIPTION
Every time I contribute to this project, I am a bit afraid of messing up stuff because the CI doesn't test all the feature combinations.

This patch switches from travis to GitHub actions as they have excellent support for arbitrary build-matrices.

Ideally, we would also have a check that verifies the MSRV this project is compatible with. I'll leave that up to you to add if you want to give guarantees to your users here.