### PR TITLE
Improve warp integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hyper = { version = "0.13", optional = true }
 actix-web = { version = "2.0", optional = true }
 actix = { version = "0.9", optional = true }
 failure = { version = "0.1", optional = true }
-warp = { version = "0.2", optional = true }
+warp = { version = "0.2", optional = true, default-features = false }
 
 [features]
 with_actix_web = ["actix-web", "actix"]

--- a/src/api_error.rs
+++ b/src/api_error.rs
@@ -333,3 +333,6 @@ impl actix_web::error::ResponseError for ApiError {
         response
     }
 }
+
+#[cfg(feature = "with_warp")]
+impl warp::reject::Reject for ApiError {}


### PR DESCRIPTION
1. We can remove all the default features from warp because we only need the `Reject` trait.
2. I've implemented `Reject` also for `ApiError` to allow users to use that for rejections as-well.