### PR TITLE
lib: make to_hyper_response accept &self

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,7 +406,7 @@ impl HttpApiProblem {
     /// If status is `None` `500 - Internal Server Error` is the
     /// default.
     #[cfg(feature = "with-hyper")]
-    pub fn to_hyper_response(self) -> hyper::Response<hyper::Body> {
+    pub fn to_hyper_response(&self) -> hyper::Response<hyper::Body> {
         use hyper::header::{HeaderValue, CONTENT_LENGTH, CONTENT_TYPE};
         use hyper::*;
 


### PR DESCRIPTION
Make `to_hyper_response` method accept reference self. Similar function API exists on `pub fn to_actix_response(&self) -> actix_web::HttpResponse` that accept `&self`.

This allows to return hyper response without "move", in cases like this:

```
if let Some(error) = err.find::<problem::HttpApiProblem>() {
  return Ok(error.to_hyper_response());
```

cc @chridou 