### PR TITLE
Update warp to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ http = { version = "0.2" }
 hyper = { version = "0.14", optional = true }
 actix-web = { version = "3", optional = true }
 actix = { version = "0.10", optional = true }
-warp = { version = "0.2", optional = true, default-features = false }
+warp = { version = "0.3", optional = true, default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
warp 0.3 was released a few days ago and is compatible with tokio 1.0