### PR TITLE
Readd stable rocket

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
             "--features 'tide api-error'",
           ]
         rust: [
-            1.46.0, # MSRV
+            1.53.0, # MSRV
             nightly, # it is good practise to test libraries against nightly to catch regressions in the compiler early
           ]
       fail-fast: false # don't want to kill the whole CI if nightly fails

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,12 +14,14 @@ jobs:
             "--features warp",
             "--features salvo",
             "--features tide",
+            "--features rocket",
             "--features api-error",
             "--features 'hyper api-error'",
             "--features 'actix-web api-error'",
             "--features 'warp api-error'",
             "--features 'salvo api-error'",
             "--features 'tide api-error'",
+            "--features 'rocket api-error'",
           ]
         rust: [
             1.53.0, # MSRV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ http = { version = "0.2" }
 hyper = { version = "0.14", optional = true }
 actix-web-crate = { package = "actix-web", version = "3", optional = true }
 actix = { version = "0.12", optional = true }
+rocket = { version = "0.5.0-rc.1", optional = true, default-features = false }
 warp = { version = "0.3", optional = true, default-features = false }
 salvo = { version = "0.11", optional = true, default-features = false }
 tide = { version = "0.16", optional = true, default-features = false }


### PR DESCRIPTION
For the last few months, Rocket has been able to compile on stable Rust. Perhaps this would be a good reason to consider re-adding support for it in this library?

I've mostly recycled the old code, adjusting it to the new Rocket API. 