### PR TITLE
Update to actix-web 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CHANGED
 
 - bump salvo dependency to 0.16
+- bump actix-web dependency to 4
+- bump actix dependency to 0.13
 
 ## [0.51.0] - 2021-11-03
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 http = { version = "0.2" }
 hyper = { version = "0.14", optional = true }
-actix-web-crate = { package = "actix-web", version = "3", optional = true }
-actix = { version = "0.12", optional = true }
+actix-web-crate = { package = "actix-web", version = "4", optional = true }
+actix = { version = "0.13", optional = true }
 rocket = { version = "0.5.0-rc.1", optional = true, default-features = false }
 warp = { version = "0.3", optional = true, default-features = false }
 salvo = { version = "0.16", optional = true, default-features = false }


### PR DESCRIPTION
Actix web has now released version 4, I need to upgrade the version used in this crate for the types to be compatible, no code changes are required though.