### PR TITLE
`IntoAPIError` and a derive macro for it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,12 @@ rocket = { version = "0.5.0-rc.1", optional = true, default-features = false }
 warp = { version = "0.3", optional = true, default-features = false }
 salvo = { version = "0.23", optional = true, default-features = false }
 tide = { version = "0.16", optional = true, default-features = false }
+derive-into-api-error = { path = "derive-into-api-error", optional = true }
 
 [features]
 default = []
 actix-web = ["actix-web-crate", "actix"]
-api-error = []
+api-error = ["derive-into-api-error"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/derive-into-api-error/Cargo.toml
+++ b/derive-into-api-error/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "derive-into-api-error"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+derive_utils = "0.12"

--- a/derive-into-api-error/src/lib.rs
+++ b/derive-into-api-error/src/lib.rs
@@ -1,0 +1,15 @@
+use derive_utils::quick_derive;
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(IntoApiError)]
+pub fn derive_iterator(input: TokenStream) -> TokenStream {
+    quick_derive! {
+        input,
+        // trait path
+        ::http_api_problem::IntoApiError,
+        // trait definition
+        pub trait IntoApiError {
+            fn into_api_error(self) -> ::http_api_problem::ApiError;
+        }
+    }
+}

--- a/src/api_error.rs
+++ b/src/api_error.rs
@@ -14,6 +14,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::*;
+pub use derive_into_api_error::IntoApiError;
 
 pub struct ApiErrorBuilder {
     /// The suggested status code for the server to be returned to the client
@@ -464,6 +465,16 @@ impl From<io::Error> for ApiError {
             .title("An IO error occurred")
             .source(error)
             .finish()
+    }
+}
+
+pub trait IntoApiError {
+    fn into_api_error(self) -> ApiError;
+}
+
+impl<T: IntoApiError> From<T> for ApiError {
+    fn from(t: T) -> ApiError {
+        t.into_api_error()
     }
 }
 


### PR DESCRIPTION
This PR implements the `IntoApiError` trait and a derive macro for this trait. 

This is for the usecase where clients want to use their own error types, but separately want to convert them into `ApiError` — possibly because the core of the application is written without reference to http, but each independent error can still be translated with reference to http problems and status codes. The derive macro is useful for cases where errors are built from enums of other errors, that already implement `IntoApiError`.