### PR TITLE
add `From<std::convert::Infallible>` impls

### DIFF
--- a/src/api_error.rs
+++ b/src/api_error.rs
@@ -561,6 +561,12 @@ impl From<io::Error> for ApiError {
     }
 }
 
+impl From<std::convert::Infallible> for ApiError {
+    fn from(error: std::convert::Infallible) -> Self {
+        match error {}
+    }
+}
+
 pub trait IntoApiError {
     fn into_api_error(self) -> ApiError;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -900,6 +900,12 @@ impl From<StatusCode> for HttpApiProblem {
     }
 }
 
+impl From<std::convert::Infallible> for HttpApiProblem {
+    fn from(error: std::convert::Infallible) -> HttpApiProblem {
+        match error {}
+    }
+}
+
 /// Creates an [hyper::Response] from something that can become an
 /// `HttpApiProblem`.
 ///


### PR DESCRIPTION
`std` uses `std::convert::Infallible` to indicate cases where an error is expected but can't happen; in particular, it auto-implements `TryFrom` for all `From` implementations, with the error type marked as `std::convert::Infallible`. It's currently implemented as an enum with no variants, so it's statically impossible to create an instance of.

In code that is attempting to be generic over `TryFrom` implementations, then, you may need to end up proving `From<Infallible> for YourErrorType`. This is trivial to implement — the rust compiler understands that it's impossible to ever be handed an instance of an enum with zero variants — but due to coherence rules, the impl needs to live next to `YourErrorType`. In this case, that means it needs to live in `http-api-problem`.

Thanks.