### PR TITLE
Feature/provide PartialEq and Eq derives for the HttpApiProblem struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.57.0] - 2023-07-04
+
+### CHANGED
+
+- provide `PartialEq` and `Eq` derives for the `HttpApiProblem` struct  
+Previously, it was only available in the test profiles
+
 ## [0.56.0] - 2022-11-25
 
 ### CHANGED

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-api-problem"
-version = "0.56.0"
+version = "0.57.0"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 description = "A library to create HTTP error response content for APIs based on RFC 7807"
 repository = "https://github.com/chridou/http-api-problem"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,8 +182,7 @@ pub static PROBLEM_JSON_MEDIA_TYPE: &str = "application/problem+json";
 /// This is a trade off so that the recipient does not have to deal with
 /// another error and can still have access to the remaining fields of the
 /// struct.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[cfg_attr(
     feature = "json-schema",


### PR DESCRIPTION
Hi @chridou,

we want to use this crate for our projects and stumbled over a tiny limitation. We need the ability to compare HttpApiProblem structs. 
The current implementation provides a `PartialEq` and `Eq` derive for the testing profile. I suggest providing those two derives in general as this would also make it usable for other use cases.

Changes:

- Move the derives from the test profile to the general availability
- Bump the crate version
- Ensure that the test cases still run successfully
- Document the change in the `Changelog.md`

Looking forward!
