### PR TITLE
2025-01-06: update dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
             "--features 'rocket api-error'",
           ]
         rust: [
-            1.79.0, # MSRV
+            1.80.0, # MSRV
             nightly, # it is good practise to test libraries against nightly to catch regressions in the compiler early
           ]
       fail-fast: false # don't want to kill the whole CI if nightly fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.60.0] - 2025-01-06
+
+### CHANGED
+
+- update `axum-core` to 0.5.0
+- update `hyper` to 1.5
+- update `salvo` to 0.75.0
+- update `http` to 1.2
+
 ## [0.59.0] - 2024-07-07
 
 ### CHANGED

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update `hyper` to 1.5
 - update `salvo` to 0.75.0
 - update `http` to 1.2
+- update MSRV to `1.80` due to the requirement from `salvo`
 
 ## [0.59.0] - 2024-07-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-api-problem"
-version = "0.59.0"
+version = "0.60.0"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 description = "A library to create HTTP error response content for APIs based on RFC 7807"
 repository = "https://github.com/chridou/http-api-problem"
@@ -15,15 +15,15 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-http = { version = "1.0" }
-hyper = { version = "1.0", optional = true }
+http = { version = "1.2" }
+hyper = { version = "1.5", optional = true }
 actix-web-crate = { package = "actix-web", version = "4", optional = true }
 actix = { version = "0.13", optional = true }
 rocket = { version = "0.5.0-rc.2", optional = true, default-features = false }
 warp = { version = "0.3", optional = true, default-features = false }
-salvo = { version = "0.68.0", optional = true, default-features = false }
+salvo = { version = "0.75.0", optional = true, default-features = false }
 tide = { version = "0.16", optional = true, default-features = false }
-axum-core = { version = "^0.4.1", optional = true }
+axum-core = { version = "0.5.0", optional = true }
 http-api-problem-derive = { version = "0.1.0", path = "http-api-problem-derive", optional = true }
 schemars = { version = "0.8.10", optional = true }
 rocket_okapi = { version = ">= 0.8.0-rc.2, < 0.10", optional = true }


### PR DESCRIPTION
Hi @chridou,

we want to update our projects to use `axum` in version 0.8. As we use `http-api-problem` in our projects and it has a dependency to `axum-core`, I want to provide a PR with the bumped dependencies 😄 

### Changes:

- update `axum-core` to 0.5.0
- update `hyper` to 1.5
- update `salvo` to 0.75.0
- update `http` to 1.2
- add entry in CHANGELOG.md

I successfully executed the tests with all features.

Best regards 🖖 
